### PR TITLE
Allow dev version to use branch from another github username

### DIFF
--- a/esphome-dev/rootfs/etc/cont-init.d/30-esphome.sh
+++ b/esphome-dev/rootfs/etc/cont-init.d/30-esphome.sh
@@ -8,7 +8,15 @@ declare esphome_version
 
 if bashio::config.has_value 'esphome_version'; then
     esphome_version=$(bashio::config 'esphome_version')
-    full_url="https://github.com/esphome/esphome/archive/${esphome_version}.zip"
+    if [[ $esphome_version == *":"* ]]; then
+      IFS=':' read -r -a array <<< "$esphome_version"
+      username=${array[0]}
+      ref=${array[1]}
+    else
+      username="esphome"
+      ref=$esphome_version
+    fi
+    full_url="https://github.com/${username}/esphome/archive/${ref}.zip"
     bashio::log.info "Installing esphome version '${esphome_version}' (${full_url})..."
     pip3 install -U --no-cache-dir "${full_url}" \
       || bashio::exit.nok "Failed installing esphome pinned version."


### PR DESCRIPTION
I have added to the startup script for the dev hassio addon allowing users to specify a branch of a fork of the [esphome](https://github.com/esphome/esphome) repository.

This allows for easier development of esphome components with the existing hassio dev addon for esphome.

Example:
```json
{
  "esphome_version": "jesserockz:component/rf_bridge"
}
```