### PR TITLE
Update readme to reflect new usage of esphome_version

### DIFF
--- a/esphome-beta/README.md
+++ b/esphome-beta/README.md
@@ -89,7 +89,11 @@ authentication by setting it to `true`.
 
 Manually override which ESPHome version to use in the add-on.
 For example to install the latest development version, use `"esphome_version": "dev"`,
-or for version 1.14.0: `"esphome_version": "v1.14.0""`.
+or for version 1.14.0: `"esphome_version": "v1.14.0"`.
+
+This can also be used to specify a branch of a fork of the esphome repository.
+For example to install the test_new_component branch of a fork made by user123, use `"user123:test_new_component"`.
+This usage assumes the forked repository is named `esphome`.
 
 Please note that this does not always work and is only meant for testing, usually the
 ESPHome add-on and dashboard version must match to guarantee a working system.

--- a/esphome-dev/README.md
+++ b/esphome-dev/README.md
@@ -89,7 +89,11 @@ authentication by setting it to `true`.
 
 Manually override which ESPHome version to use in the add-on.
 For example to install the latest development version, use `"esphome_version": "dev"`,
-or for version 1.14.0: `"esphome_version": "v1.14.0""`.
+or for version 1.14.0: `"esphome_version": "v1.14.0"`.
+
+This can also be used to specify a branch of a fork of the esphome repository.
+For example to install the test_new_component branch of a fork made by user123, use `"user123:test_new_component"`.
+This usage assumes the forked repository is named `esphome`.
 
 Please note that this does not always work and is only meant for testing, usually the
 ESPHome add-on and dashboard version must match to guarantee a working system.

--- a/esphome/README.md
+++ b/esphome/README.md
@@ -89,7 +89,11 @@ authentication by setting it to `true`.
 
 Manually override which ESPHome version to use in the add-on.
 For example to install the latest development version, use `"esphome_version": "dev"`,
-or for version 1.14.0: `"esphome_version": "v1.14.0""`.
+or for version 1.14.0: `"esphome_version": "v1.14.0"`.
+
+This can also be used to specify a branch of a fork of the esphome repository.
+For example to install the test_new_component branch of a fork made by user123, use `"user123:test_new_component"`.
+This usage assumes the forked repository is named `esphome`.
 
 Please note that this does not always work and is only meant for testing, usually the
 ESPHome add-on and dashboard version must match to guarantee a working system.

--- a/template/README.md
+++ b/template/README.md
@@ -89,7 +89,11 @@ authentication by setting it to `true`.
 
 Manually override which ESPHome version to use in the add-on.
 For example to install the latest development version, use `"esphome_version": "dev"`,
-or for version 1.14.0: `"esphome_version": "v1.14.0""`.
+or for version 1.14.0: `"esphome_version": "v1.14.0"`.
+
+This can also be used to specify a branch of a fork of the esphome repository.
+For example to install the test_new_component branch of a fork made by user123, use `"user123:test_new_component"`.
+This usage assumes the forked repository is named `esphome`.
 
 Please note that this does not always work and is only meant for testing, usually the
 ESPHome add-on and dashboard version must match to guarantee a working system.


### PR DESCRIPTION
This PR updates the readme files to reflect the new option added [in this previous PR](https://github.com/esphome/hassio/pull/5), which allows the `esphome_version` configuration option to allow pulling the code from a branch from another github username.

Also edited the line above my changes to correct a typo.