### PR TITLE
Fix config style for new Supervisor/Hardware

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  build:
+    name: Add-on configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: 🚀 Run Home Assistant Add-on Lint on ESPHome
+        uses: frenck/action-addon-linter@v2
+        with:
+          path: "./esphome"
+      - name: 🚀 Run Home Assistant Add-on Lint on ESPHome-Beta
+        uses: frenck/action-addon-linter@v2
+        with:
+          path: "./esphome-beta"
+      - name: 🚀 Run Home Assistant Add-on Lint on ESPHome-Dev
+        uses: frenck/action-addon-linter@v2
+        with:
+          path: "./esphome-dev"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,18 +4,13 @@ jobs:
   build:
     name: Add-on configuration
     runs-on: ubuntu-latest
+    strategy:
+       matrix:
+         channel: [esphome, esphome-beta, esphome-dev]
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v2
-      - name: 🚀 Run Home Assistant Add-on Lint on ESPHome
+      - name: 🚀 Run Home Assistant Add-on Lint on ${{ matrix.channel }}
         uses: frenck/action-addon-linter@v2
         with:
-          path: "./esphome"
-      - name: 🚀 Run Home Assistant Add-on Lint on ESPHome-Beta
-        uses: frenck/action-addon-linter@v2
-        with:
-          path: "./esphome-beta"
-      - name: 🚀 Run Home Assistant Add-on Lint on ESPHome-Dev
-        uses: frenck/action-addon-linter@v2
-        with:
-          path: "./esphome-dev"
+          path: "./${{ matrix.channel }}"

--- a/esphome-beta/config.json
+++ b/esphome-beta/config.json
@@ -8,8 +8,6 @@
   "uart": true,
   "description": "Beta version of ESPHome Hass.io add-on.",
   "hassio_api": true,
-  "hassio_role": "default",
-  "homeassistant_api": false,
   "host_network": true,
   "image": "esphome/esphome-hassio-{arch}",
   "ingress": true,
@@ -19,7 +17,6 @@
     "config:rw"
   ],
   "name": "ESPHome (beta)",
-  "options": {},
   "panel_icon": "mdi:chip",
   "ports": {
     "6052/tcp": null
@@ -40,6 +37,5 @@
   "slug": "esphome-beta",
   "stage": "experimental",
   "url": "https://beta.esphome.io/",
-  "version": "1.16.0",
-  "webui": "http://[HOST]:[PORT:6052]"
+  "version": "1.16.0"
 }

--- a/esphome-beta/config.json
+++ b/esphome-beta/config.json
@@ -5,8 +5,7 @@
     "aarch64"
   ],
   "auth_api": true,
-  "auto_uart": true,
-  "boot": "auto",
+  "uart": true,
   "description": "Beta version of ESPHome Hass.io add-on.",
   "hassio_api": true,
   "hassio_role": "default",
@@ -40,7 +39,6 @@
   },
   "slug": "esphome-beta",
   "stage": "experimental",
-  "startup": "application",
   "url": "https://beta.esphome.io/",
   "version": "1.16.0",
   "webui": "http://[HOST]:[PORT:6052]"

--- a/esphome-dev/build.json
+++ b/esphome-dev/build.json
@@ -1,9 +1,7 @@
 {
-  "args": {},
   "build_from": {
     "aarch64": "esphome/esphome-hassio-base-aarch64:2.5.0",
     "amd64": "esphome/esphome-hassio-base-amd64:2.5.0",
     "armv7": "esphome/esphome-hassio-base-armv7:2.5.0"
-  },
-  "squash": false
+  }
 }

--- a/esphome-dev/config.json
+++ b/esphome-dev/config.json
@@ -5,8 +5,7 @@
     "aarch64"
   ],
   "auth_api": true,
-  "auto_uart": true,
-  "boot": "auto",
+  "uart": true,
   "description": "Development Version! Manage and program ESP8266/ESP32 microcontrollers through YAML configuration files",
   "hassio_api": true,
   "hassio_role": "default",
@@ -41,7 +40,6 @@
   },
   "slug": "esphome-dev",
   "stage": "experimental",
-  "startup": "application",
   "url": "https://next.esphome.io/",
   "version": "dev",
   "webui": "http://[HOST]:[PORT:6052]"

--- a/esphome-dev/config.json
+++ b/esphome-dev/config.json
@@ -8,8 +8,6 @@
   "uart": true,
   "description": "Development Version! Manage and program ESP8266/ESP32 microcontrollers through YAML configuration files",
   "hassio_api": true,
-  "hassio_role": "default",
-  "homeassistant_api": false,
   "host_network": true,
   "ingress": true,
   "ingress_port": 0,
@@ -41,6 +39,5 @@
   "slug": "esphome-dev",
   "stage": "experimental",
   "url": "https://next.esphome.io/",
-  "version": "dev",
-  "webui": "http://[HOST]:[PORT:6052]"
+  "version": "dev"
 }

--- a/esphome/config.json
+++ b/esphome/config.json
@@ -5,8 +5,7 @@
     "aarch64"
   ],
   "auth_api": true,
-  "auto_uart": true,
-  "boot": "auto",
+  "uart": true,
   "description": "ESPHome Hass.io add-on for intelligently managing all your ESP8266/ESP32 devices.",
   "hassio_api": true,
   "hassio_role": "default",
@@ -40,7 +39,6 @@
   },
   "slug": "esphome",
   "stage": "stable",
-  "startup": "application",
   "url": "https://esphome.io/",
   "version": "1.16.0",
   "webui": "http://[HOST]:[PORT:6052]"

--- a/esphome/config.json
+++ b/esphome/config.json
@@ -8,8 +8,6 @@
   "uart": true,
   "description": "ESPHome Hass.io add-on for intelligently managing all your ESP8266/ESP32 devices.",
   "hassio_api": true,
-  "hassio_role": "default",
-  "homeassistant_api": false,
   "host_network": true,
   "image": "esphome/esphome-hassio-{arch}",
   "ingress": true,
@@ -19,7 +17,6 @@
     "config:rw"
   ],
   "name": "ESPHome",
-  "options": {},
   "panel_icon": "mdi:chip",
   "ports": {
     "6052/tcp": null
@@ -38,8 +35,6 @@
     "streamer_mode": "bool?"
   },
   "slug": "esphome",
-  "stage": "stable",
   "url": "https://esphome.io/",
-  "version": "1.16.0",
-  "webui": "http://[HOST]:[PORT:6052]"
+  "version": "1.16.0"
 }


### PR DESCRIPTION
Fixes: https://github.com/esphome/issues/issues/1806

Since version `2021.02.0` of the home assistant supervisor, there is a new way of handling hardware:
https://github.com/home-assistant/supervisor/pull/2429

This PR is intended to update the config files to the latest requirements.

Here is an example, how the addons from the core repository are fixed:
https://github.com/home-assistant/addons/pull/1825