### PR TITLE
Publish stable builds to beta addon repo

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -55,8 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-release]
     steps:
-    - if: ${{ contains(github.event.inputs.version, 'b') }}
-      name: Publish beta release to community-addons repository
+    - name: Publish beta release to community-addons repository
       run: |
         docker run --rm hassioaddons/repository-updater:latest \
           --repository hassio-addons/repository-beta \


### PR DESCRIPTION
The `bump_version.py` script already updates the `esphome-beta/config.json` file, but we don't push the update to the community addons beta repo.
This fixes that.