### PR TITLE
Exclude unnecessary data from snapshots

### DIFF
--- a/esphome-dev/config.json
+++ b/esphome-dev/config.json
@@ -36,6 +36,9 @@
     "streamer_mode": "bool?"
   },
   "slug": "esphome-dev",
+  "snapshot_exclude": [
+    "*/*/"
+  ],
   "stage": "experimental",
   "uart": true,
   "url": "https://next.esphome.io/",

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -32,6 +32,8 @@ base: &base
     streamer_mode: bool?
     relative_url: str?
     status_use_ping: bool?
+  snapshot_exclude:
+    - */*/
   base_image: esphome/esphome-hassio-base-{arch}:3.1.0
 
 esphome-dev:

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -33,7 +33,7 @@ base: &base
     relative_url: str?
     status_use_ping: bool?
   snapshot_exclude:
-    - */*/
+    - "*/*/"
   base_image: esphome/esphome-hassio-base-{arch}:3.1.0
 
 esphome-dev:


### PR DESCRIPTION
Home Assistant recently added the ability for addons to exclude specific data from snapshots https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-config

As mentioned in esphome/issues#349, the files/folders under `/data` do not need to backed up and can also take up a large amount of space. This PR adds the new `snapshot_exclude` option to exclude all folders under `/data`.

I've tested this change locally and it correctly excludes the folders under `/data`