### PR TITLE
Remove esphome_version from the addon options

### DIFF
--- a/esphome-dev/config.json
+++ b/esphome-dev/config.json
@@ -5,7 +5,7 @@
     "aarch64"
   ],
   "auth_api": true,
-  "description": "Development Version! Manage and program ESP8266/ESP32 microcontrollers through YAML configuration files",
+  "description": "Development version of ESPHome add-on",
   "hassio_api": true,
   "host_network": true,
   "ingress": true,
@@ -15,19 +15,15 @@
     "config:rw"
   ],
   "name": "ESPHome (dev)",
-  "options": {
-    "esphome_version": "dev"
-  },
   "panel_icon": "mdi:chip",
   "ports": {
     "6052/tcp": null
   },
   "ports_description": {
-    "6052/tcp": "Web interface (Not required for Home Assistant Ingress)"
+    "6052/tcp": "Web interface (not required for Home Assistant ingress)"
   },
   "schema": {
     "certfile": "str?",
-    "esphome_version": "str?",
     "keyfile": "str?",
     "leave_front_door_open": "bool?",
     "relative_url": "str?",

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -1,6 +1,6 @@
 ---
 # When changing options in this file, please also run:
-#    python3 script/generate.py dev 
+#    python3 script/generate.py dev
 # to update the dev addon config (beta/stable configs will be updated on next release by release script)
 base: &base
   url: https://esphome.io/
@@ -31,7 +31,6 @@ base: &base
     certfile: str?
     keyfile: str?
     leave_front_door_open: bool?
-    esphome_version: str?
     streamer_mode: bool?
     relative_url: str?
     status_use_ping: bool?
@@ -48,8 +47,6 @@ esphome-dev:
   description: "Development version of ESPHome add-on"
   url: https://next.esphome.io/
   stage: experimental
-  options:
-    esphome_version: dev
 
 esphome-beta:
   <<: *base


### PR DESCRIPTION
This removes `esphome_version` from the addon options
- https://github.com/esphome/esphome/pull/1937

Beta and release will be generated at their next release (1.21.0b1 and 1.21.0 respectively) which will have the script removed at the same time.