### PR TITLE
Fix warning when starting dev container

### DIFF
--- a/esphome-dev/rootfs/etc/services.d/esphome/run
+++ b/esphome-dev/rootfs/etc/services.d/esphome/run
@@ -23,4 +23,4 @@ if bashio::config.has_value 'relative_url'; then
 fi
 
 bashio::log.info "Starting ESPHome dashboard..."
-exec esphome /config/esphome dashboard --socket /var/run/esphome.sock --hassio
+exec esphome dashboard /config/esphome --socket /var/run/esphome.sock --hassio


### PR DESCRIPTION
Fixes the following warning when starting the "ESPHome (dev)" addon:

```
WARNING Calling ESPHome with the configuration before the command is deprecated and will be removed in the future. 
WARNING Please instead use:
WARNING    esphome dashboard /config/esphome --socket /var/run/esphome.sock --hassio
```